### PR TITLE
Feat polymorphic heading

### DIFF
--- a/components/About/About.tsx
+++ b/components/About/About.tsx
@@ -14,6 +14,7 @@ const About = ({ children }: AboutProps): JSX.Element => {
       columnsMediaBreakpoint={600}
     >
       <Heading
+        as='h2'
         accentType="number"
         accentText="02."
         title="About"

--- a/components/ui/Heading/Heading.tsx
+++ b/components/ui/Heading/Heading.tsx
@@ -15,24 +15,32 @@ type AccentNumber = {
   accentType: 'number';
   accentText: '01.' | '02.' | '03.';
 };
-type HeadingText = {
+
+type HeadingOwnProps<T extends React.ElementType> = {
   headingText: string;
   title: Title;
+  as?: T;
 };
-type HeadingProps = HeadingText & (AccentDot | AccentNumber);
 
-const Heading = ({
+type HeadingProps<T extends React.ElementType> = HeadingOwnProps<T> &
+  (AccentDot | AccentNumber) &
+  Omit<React.ComponentPropsWithoutRef<T>, keyof HeadingOwnProps<T>>;
+
+const Heading = <T extends React.ElementType = 'h1'>({
   accentType,
   accentText,
   headingText,
   title,
-}: HeadingProps) => {
+  as,
+  ...rest
+}: HeadingProps<T>) => {
+  const Component = as || 'h1';
   if (accentType === 'number') {
     return (
       <section className={section}>
-        <h1 className={header}>
+        <Component className={header} {...rest}>
           <span className={accent}>{accentText}</span> {headingText}
-        </h1>
+        </Component>
         <div className={pageTitle}>{title}</div>
       </section>
     );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,6 +21,7 @@ export default function Home() {
         overflow="hiddenX"
       >
         <Heading
+          as='h2'
           accentType="number"
           accentText="01."
           headingText="Some things I've build."


### PR DESCRIPTION
'Heading' component render heading tag based on the 'as' prop.
It should be used to only render H1 - H6 tags.